### PR TITLE
We might want to compare files using hashes in the future

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ghoR
 Type: Package
 Title: R interface for the GHO API of the WHO
 Version: 0.1.0
-Author: M. van der Broek
+Author: M. van der Broek, Shady el-Gewily
 Maintainer: M. van der Broek <markvanderbroek@gmail.com>
 Description: This package provides an interface to load data from the GHO API.
     The GHO API provides all publicly available data provided by the WHO.
@@ -12,5 +12,6 @@ LazyData: true
 Imports:
     dplyr,
     rjson,
-    data.table
+    data.table,
+    digest
 RoxygenNote: 7.0.2

--- a/R/test.R
+++ b/R/test.R
@@ -1,0 +1,4 @@
+source( "R/utils.R" )
+
+data = download_ind("RSUD_30")
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,3 +86,15 @@ null_to_NA_list <- function(list) {
 
   return(list)
 }
+
+#' Generate a SHA256 hash file from a downloaded WHO data file
+#'
+#' @param list A data object
+#' @return A character string of length 64 containing the SHA256 string
+create_hash_from_data <- function(data)
+{
+  return( digest(data, algo="sha256", serialize=T) )
+
+  #Potentially insert the hash with the date of generation, WHO Indicator and other metadata in a centrally accessible online SQL database
+  #So that we can check whether a date file has been updated (compared to the cached local version)
+}

--- a/man/create_hash_from_data.Rd
+++ b/man/create_hash_from_data.Rd
@@ -1,0 +1,23 @@
+\name{create_hash_from_data}
+\alias{create_hash_from_data}
+%- Also NEED an '\alias' for EACH other topic documented here.
+\title{Generate a SHA256 hash file from a downloaded WHO data file}
+\description{
+Creates a character string of length 64 containing the SHA256 hash of a given downloaded WHO data file. This is useful for comparing two data files and to detect whether a file has been changed/updated.
+}
+\usage{
+create_hash_from_data(data)
+}
+%- maybe also 'usage' for other objects documented here.
+\arguments{
+  \item{data}{      The downloaded WHO data file}
+}
+
+\value{a character string of length 64 containing the SHA256 hash}
+
+\author{Shady el Gewily}
+
+\examples{
+data = download_ind("RSUD_30")
+hash = create_hash_from_data(data)
+}


### PR DESCRIPTION
We can check for updates by comparing the SHA256 hash of a downloaded file to a SHA256 hash of a previously downloaded file. Ideally we have a database with SHA256 hashes with the date 'Last downloaded/updated' so we can compare the hashes to decide whether a new version needs to be downloaded.